### PR TITLE
news comments list and spam evaluation for admin CP

### DIFF
--- a/www/admin/admin_news_comments_list.php
+++ b/www/admin/admin_news_comments_list.php
@@ -1,0 +1,180 @@
+<?php
+/*
+    This file is part of the Frogsystem Spam Detector.
+    Copyright (C) 2011  Thoronador
+
+    The Frogsystem Spam Detector is free software: you can redistribute it
+    and/or modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the License,
+    or (at your option) any later version.
+
+    The Frogsystem Spam Detector is distributed in the hope that it will be
+    useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+  if (!isset($_GET['start']) || $_GET['start']<0)
+  {
+    $_GET['start'] = 0;
+  }
+  $_GET['start'] = (int) $_GET['start'];
+  settype($_GET['start'], "integer");
+  //Anzahl der Kommentare auslesen
+  $query = mysql_query('SELECT COUNT(comment_id) AS cc FROM `'.$global_config_arr['pref'].'news_comments`', $db);
+  $cc = mysql_fetch_assoc($query);
+  $cc = (int) $cc['cc'];
+  if ($_GET['start']>=$cc)
+  {
+    $_GET['start'] = $cc - ($cc % 30);
+  }
+
+  //Kommentare auslesen
+  $query = mysql_query('SELECT comment_id, comment_title, comment_date, comment_poster, comment_poster_id, comment_text, '
+                      .'`'.$global_config_arr['pref'].'news_comments`.news_id AS news_id, `'.$global_config_arr['pref'].'news`.news_id, news_title '
+                      .'FROM `'.$global_config_arr['pref'].'news_comments`, `'.$global_config_arr['pref'].'news` '
+                      .'WHERE `'.$global_config_arr['pref'].'news_comments`.news_id=`'.$global_config_arr['pref'].'news`.news_id '
+                      .'ORDER BY comment_date DESC LIMIT '.$_GET['start'].', 30', $db);
+  $rows = mysql_num_rows($query);
+
+  //Bereich (zahlenm‰ﬂig)
+  $bereich = '<font class="small">'.($_GET['start']+1).' ... '.($_GET[start] + $rows).'</font>';
+  //Ist dies nicht die erste Seite?
+  if ($_GET['start']>0)
+  {
+    $prev_start = $_GET['start']-30;
+    if ($prev_start<0)
+    {
+      $prev_start = 0;
+    }
+    $prev_page = '<a href="'.$PHP_SELF.'?go=news_comments_list&start='.$prev_start.'"><- zur¸ck</a>';
+  }//if nicht erste Seite
+  //Ist dies nicht die letzte Seite?
+  if ($_GET['start']+30<$cc)
+  {
+    $next_page = '<a href="'.$PHP_SELF.'?go=news_comments_list&start='.($_GET['start']+30).'">weiter -></a>';
+  }//if nicht die letzte Seite
+
+?>
+  <table class="configtable" cellpadding="4" cellspacing="0">
+    <tr>
+      <td class="line" colspan="5">Kommentarliste</td>
+    </tr>
+    <tr>
+      <td class="config" width="30%">
+          Titel
+      </td>
+      <td class="config" width="30%">
+          Poster
+      </td>
+      <td class="config" width="20%">
+          Datum
+      </td>
+      <td class="config" width="10%">
+          Spamwahrscheinlichkeit
+      </td>
+      <td class="config" width="10%">
+          bearbeiten
+      </td>
+    </tr>
+<?php
+  require_once 'eval_spam.inc.php';
+
+  while ($comment_arr = mysql_fetch_assoc($query))
+  {
+    if ($comment_arr['comment_poster_id'] != 0)
+    {
+      $userindex = mysql_query('SELECT user_name FROM `'.$global_config_arr['pref'].'user` WHERE user_id = \''.$comment_arr['comment_poster_id'].'\'', $db);
+      $comment_arr['comment_poster'] = mysql_result($userindex, 0, 'user_name');
+    }
+    $comment_arr['comment_date'] = date('d.m.Y' , $comment_arr['comment_date'])
+                                      ." um ".date('H:i' , $comment_arr['comment_date']);
+    echo'<tr>
+           <td class="config">
+               '.$comment_arr['comment_title'].'
+           </td>
+           <td class="config">
+               '.$comment_arr['comment_poster'];
+    if ($comment_arr['comment_poster_id'] == 0)
+    {
+      echo '<br><small>(unregistriert)</small>';
+    }
+    echo '           </td>
+           <td class="config">
+               '.$comment_arr['comment_date'].'
+           </td>
+           <td class="config">
+               '.spamLevelToText(spamEvaluation($comment_arr['comment_title'],
+                 $comment_arr['comment_poster_id'], $comment_arr['comment_poster'], $comment_arr['comment_text'])).'
+           </td>
+           <td class="config" rowspan="2">
+             <form action="'.$PHP_SELF.'" method="post">
+               <input type="hidden" name="sended" value="comment">
+               <input type="hidden" name="news_action" value="comments">
+               <input type="hidden" name="news_id" value="'.$comment_arr['news_id'].'">
+               <input type="hidden" name="go" value="news_edit">
+               <input type="hidden" name="comment_id[]" value="'.$comment_arr['comment_id'].'">
+               <input type="hidden" name="comment_action" value="edit">
+               <input class="button" type="submit" value="Editieren">
+             </form>
+
+             <form action="'.$PHP_SELF.'" method="post">
+               <input type="hidden" name="sended" value="comment">
+               <input type="hidden" name="news_action" value="comments">
+               <input type="hidden" name="news_id" value="'.$comment_arr['news_id'].'">
+               <input type="hidden" name="go" value="news_edit">
+               <input type="hidden" name="comment_id[]" value="'.$comment_arr['comment_id'].'">
+               <input type="hidden" name="comment_action" value="delete">
+               <input class="button" type="submit" value="L&ouml;schen">
+             </form>
+           </td>
+         </tr>
+         <tr>
+           <td style="text-align:center;" colspan="4"><font size="1">Zugeh&ouml;rige Newsmeldung: <a href="../?go=comments&id='
+                                              .$comment_arr['news_id'].'" target="_blank">&quot;'
+                                              .htmlentities($comment_arr['news_title'], ENT_QUOTES).'&quot;</a></font>
+           </td>
+         </tr>
+         <tr>
+           <td colspan="5"><hr width="95%" style="color: #cccccc; background-color: #cccccc;"></td>
+         </tr>';
+  }//while
+?>
+    <tr>
+      <td colspan="5">
+          &nbsp;
+      </td>
+    </tr>
+  </table>
+
+                        <table class="configtable" cellpadding="4" cellspacing="0">
+                            <tr valign="middle">
+                                <td width="33%" class="configthin middle">
+<?php
+  if (isset($prev_page))
+  {
+    echo $prev_page;
+  }
+?>
+                                </td>
+                                <td width="33%" align="center" class="middle">
+<?php
+  if (isset($bereich))
+  {
+    echo $bereich;
+  }
+?>
+                                </td>
+                                <td width="33%" style="text-align:right;" class="configthin middle">
+<?php
+  if (isset($next_page))
+  {
+    echo $next_page;
+  }
+?>
+                                </td>
+                            </tr>
+                        </table>

--- a/www/admin/eval_spam.inc.php
+++ b/www/admin/eval_spam.inc.php
@@ -1,0 +1,136 @@
+<?php
+/*
+    This file is part of the Frogsystem Spam Detector.
+    Copyright (C) 2011  Thoronador
+
+    The Frogsystem Spam Detector is free software: you can redistribute it
+    and/or modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation, either version 3 of the License,
+    or (at your option) any later version.
+
+    The Frogsystem Spam Detector is distributed in the hope that it will be
+    useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+  /* configuration "constants" */
+  /* lower_level_for_registered_users - if this is true, comments of registered
+     users will have a spam level one lower than unregistered users. If this is
+     false, those comments don't get the bonus. */
+  define('lower_level_for_registered_users', true);
+
+  //functions
+  /* returns true, if the first three characters of the given string do not
+     contain any vowels. Returns false otherwise.
+
+     parameters:
+         $input - a string of at least three (3) characters
+  */
+  function noVowel($input)
+  {
+    $sub = strtolower(substr($input, 0, 3));
+    $no_vowel = true;
+    for($i=0; $i<3 && $no_vowel; $i=$i+1)
+    {
+      if ($sub[$i]=='a' || $sub[$i]=='e' || $sub[$i]=='i' || $sub[$i]=='o' || $sub[$i]=='u')
+      {
+        $no_vowel = false;
+      }
+    }//for
+    return $no_vowel;
+  }//function
+
+  /* returns true, if the first three characters of the given string do have
+     a "strange" change of upper and lower case. Returns false otherwise.
+
+     parameters:
+         $input - a string of at least three (3) characters
+  */
+  function strangeCase($input)
+  {
+    $sub = substr($title, 0, 3);
+    $case_profile = 0;
+    for($i=0; $i<3; $i=$i+1)
+    {
+      if (strtoupper($sub[$i])==$sub[$i])
+      {
+        $case_profile = $case_profile + (1 << (2-$i));
+      }
+    }//for
+    return ($case_profile!=0 && $case_profile<4);
+  }//function
+
+  /* evaluates a comment and returns its "spam level", i.e. an integer value
+     that indicates the likeliness of a comment being spam. Main criterion is
+     the number of links included in the comment's text.
+     A return value of zero means that the comment does not seem to be spam, a
+     value of three or higher indicates that the comment is most likely to be
+     a spam comment. Values in between indicate that the comment might be spam.
+
+     parameters:
+         title        - the title of the comment
+         poster_id    - the ID of the user who posted the comment; must be zero
+                        for an unregistered user
+         poster_name  - the name of the user who posted the comment
+         comment_text - the comment's complete text
+  */
+  function spamEvaluation($title, $poster_id, $poster_name, $comment_text)
+  {
+    //test for url tags in comment text
+    // ---- raise level for every opening url tag
+    $comment_text = strtolower($comment_text);
+    $spam_level = substr_count($comment_text, '[url=') //URL tag with name
+                 + substr_count($comment_text, '[url]') //URL tag w/o name
+                 + substr_count($comment_text, '[link') //invalid URL tag, but some bots seem to use that one
+                 + substr_count($comment_text, '<a href='); //HTML links
+    // ---- if no spam was found so far, check for plain URLs
+    if ($spam_level==0)
+    {
+      $spam_level = substr_count($comment_text, 'http://');
+    }
+    //test for poster being not a registered user
+    if ($poster_id!=0 && strlen($poster_name)>=3)
+    {
+      //check for name
+      if (noVowel($poster_name) || strangeCase($poster_name))
+      {
+        $spam_level = $spam_level +1;
+      }
+    }//if
+    //test for strange title
+    if (($poster_id!=0) && (strlen($title)>=3))
+    {
+      if (noVowel($title) || strangeCase($title))
+      {
+        $spam_level = $spam_level +1;
+      }
+    }//if title
+    //lower spam level for registered users?
+    if (lower_level_for_registered_users && ($poster_id!=0) && ($spam_level>0))
+    {
+      $spam_level = $spam_level -1;
+    }//if
+    return $spam_level;
+  }//function
+
+  /* turns the given spam level into a human-readable text with approoriate
+     colour and returns that as HTML code snippet
+
+     parameters:
+         level - the spam level, an integer value (ideally the one returned by
+                 the spamEvaluation() function)
+  */
+  function spamLevelToText($level)
+  {
+    if ($level<=0) return '<font color="#00cc00">unwahrscheinlich</font>';
+    if ($level==1) return '<font color="#cccc00">gering</font>';
+    if ($level==2) return '<font color="#ff8000">mittel</font>';
+    //3 or higher
+    return '<font color="#ff0000"><b>hoch</b></font>';
+  }//function
+?>

--- a/www/admin/news_comments_list.sql
+++ b/www/admin/news_comments_list.sql
@@ -1,0 +1,8 @@
+--
+-- Zusatz für Tabelle `fs2_news_comments`
+-- 
+-- einmalig nach Installation der Datei admin_news_comments_list.php auszuführen
+--
+
+INSERT INTO `fs2_admin_cp` (`page_id`, `group_id`, `page_title`, `page_link`, `page_file`, `page_pos`, `page_int_sub_perm`)
+VALUES ('news_comments_list', 5, 'Kommentare', 'Kommentare', 'admin_news_comments_list.php', 4, 0);


### PR DESCRIPTION
added: news comments list and spam evaluation for admin CP

(tested with alix5c only, may need some minor adjustments for alix6 like the replacement of $db you did earlier)
