### PR TITLE
fix: correction of require() call + access restriction in admin_findpicture.php

### DIFF
--- a/www/admin/admin_findpicture.php
+++ b/www/admin/admin_findpicture.php
@@ -1,14 +1,16 @@
-<?php if (!defined('ACP_GO')) die('Unauthorized access!');
+<?php
+/*commented out, because script is usually not called via index.php, but via
+  JavaScript open() Thus, ACP_GO is not set, even for authorized users. */
+//if (!defined('ACP_GO')) die('Unauthorized access!');
 
 // Start Session
 session_start();
 
 // fs2 include path
 set_include_path ( '.' );
-define ( FS2_ROOT_PATH, './../', TRUE );
-
+define ( 'FS2_ROOT_PATH', './../', TRUE );
 require( FS2_ROOT_PATH . 'login.inc.php');
-require( FS2_ROOT_PATH . 'includes/functions.php');
+require( FS2_ROOT_PATH . 'includes/imagefunctions.php');
 require( FS2_ROOT_PATH . 'includes/adminfunctions.php');
 
 echo'

--- a/www/admin/admin_randompic_time_add.php
+++ b/www/admin/admin_randompic_time_add.php
@@ -47,6 +47,8 @@ else
         $_POST['endmin'] = date('i', $end);
     }
 
+    if (!isset($_POST['screen_id'])) $_POST['screen_id'] = '';
+
     echo'
                     <form action="" enctype="multipart/form-data" method="post">
                         <input type="hidden" value="timedpic_add" name="go">
@@ -58,7 +60,7 @@ else
                                     <font class="small">Bild ausw&auml;hlen</font>
                                 </td>
                                 <td valign="top" width="240">
-                                    <input type="button" class="button" value="Bild ausw&auml;hlen" onClick=\'open("admin_findpicture.php","Bild","width=360,height=300,screenX=50,screenY=50,scrollbars=YES")\'">
+                                    <input type="button" class="button" value="Bild ausw&auml;hlen" onClick=\'open("admin_findpicture.php","Bild","width=360,height=300,screenX=50,screenY=50,scrollbars=YES")\'>
                                     <input type="text" id="screen_selectortext" value="'. (!empty($_POST['screen_id'])?'Bild ausgew&auml;hlt!':'Kein Bild gew&auml;hlt!') .'" size="17" readonly="readonly" class="text">
                                     <input type="hidden" id="screen_id" name="screen_id" value="'. $_POST['screen_id'] .'">
                                 </td>


### PR DESCRIPTION
The attached code corrects an incorrect require() call in admin_findpicture.php, that resulted in call to an undefined function or redeclaration of an existing function. Furthermore, the access guard in that file is removed, because this would prevent authorized users from accessing the file, too.

It also removes the cause of a notice about undefined index/var in admin_randompic_time_add.php.
