### PR TITLE
replace call to deprecated function set_magic_quotes_runtime()

### DIFF
--- a/www/imageviewer.php
+++ b/www/imageviewer.php
@@ -2,11 +2,11 @@
 // Start Session
 session_start ();
 // Disable magic_quotes_runtime
-set_magic_quotes_runtime ( FALSE );
+ini_set( 'magic_quotes_runtime', '0' );
 
 // fs2 include path
 set_include_path ( '.' );
-define ( FS2_ROOT_PATH, './', TRUE );
+define ( 'FS2_ROOT_PATH', './', TRUE );
 
 // Inlcude DB Connection File
 require ( FS2_ROOT_PATH . 'login.inc.php');
@@ -25,7 +25,6 @@ if ($FD->sql()->conn() )
 
     // Constructor Calls
     set_style ();
-
 
     // Security Functions
     $_GET['id'] = ( isset ( $_GET['screenid'] ) ) ? $_GET['screenid'] : $_GET['id'];


### PR DESCRIPTION
The function [set_magic_quotes_runtime()](http://us3.php.net/manual/en/function.set-magic-quotes-runtime.php) is deprecated as of PHP 5.3 and was removed as of PHP 5.4.

In order to avoid a deprecated notice during execution of imageviewer.php, the function was replaced by ini_set().
