### PR TITLE
generalise comments to allow easier extension of comments in future

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -886,13 +886,14 @@ INSERT INTO `fs2_news_cat` (`cat_id`, `cat_name`, `cat_description`, `cat_date`,
 -- --------------------------------------------------------
 
 --
--- Tabellenstruktur für Tabelle `fs2_news_comments`
+-- Tabellenstruktur für Tabelle `fs2_comments`
 --
 
-DROP TABLE IF EXISTS `fs2_news_comments`;
-CREATE TABLE `fs2_news_comments` (
+DROP TABLE IF EXISTS `fs2_comments`;
+CREATE TABLE `fs2_comments` (
   `comment_id` mediumint(8) NOT NULL AUTO_INCREMENT,
-  `news_id` mediumint(8) DEFAULT NULL,
+  `content_id` mediumint(8) NOT NULL,
+  `content_type` varchar(32) NOT NULL,
   `comment_poster` varchar(32) DEFAULT NULL,
   `comment_poster_id` mediumint(8) DEFAULT NULL,
   `comment_poster_ip` varchar(16) NOT NULL,
@@ -904,11 +905,11 @@ CREATE TABLE `fs2_news_comments` (
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=6 ;
 
 --
--- Daten für Tabelle `fs2_news_comments`
+-- Daten für Tabelle `fs2_comments`
 --
 
-INSERT INTO `fs2_news_comments` (`comment_id`, `news_id`, `comment_poster`, `comment_poster_id`, `comment_poster_ip`, `comment_date`, `comment_title`, `comment_text`) VALUES
-(3, 5, '1', 1, '127.0.0.1', 1306441173, 'hans', 'hans');
+INSERT INTO `fs2_comments` (`comment_id`, `content_id`, `content_type`, `comment_poster`, `comment_poster_id`, `comment_poster_ip`, `comment_date`, `comment_title`, `comment_text`) VALUES
+(3, 5, 'news', '1', 1, '127.0.0.1', 1306441173, 'hans', 'hans');
 
 -- --------------------------------------------------------
 

--- a/www/admin/admin_news_comments_list.php
+++ b/www/admin/admin_news_comments_list.php
@@ -16,7 +16,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-    
+
     Additional permission under GNU GPL version 3 section 7
 
     If you modify this Program, or any covered work, by linking or combining it
@@ -27,7 +27,7 @@
     combination shall include the source code for the parts of Frogsystem used
     as well as that of the covered work.
 */
-    
+
 // perform comment actions
 
 
@@ -96,7 +96,7 @@
   $_GET['start'] = (int) $_GET['start'];
   settype($_GET['start'], 'integer');
   //Anzahl der Kommentare auslesen
-  $query = mysql_query('SELECT COUNT(comment_id) AS cc FROM `'.$FD->config('pref').'news_comments`', $FD->sql()->conn());
+  $query = mysql_query('SELECT COUNT(comment_id) AS cc FROM `'.$FD->config('pref').'comments` WHERE content_type=\'news\'', $FD->sql()->conn());
   $cc = mysql_fetch_assoc($query);
   $cc = (int) $cc['cc'];
   if ($_GET['start']>=$cc)
@@ -106,9 +106,10 @@
 
   //Kommentare auslesen
   $query = mysql_query('SELECT comment_id, comment_title, comment_date, comment_poster, comment_poster_id, comment_text, '
-                      .'`'.$FD->config('pref').'news_comments`.news_id AS news_id, `'.$FD->config('pref').'news`.news_id, news_title '
-                      .'FROM `'.$FD->config('pref').'news_comments`, `'.$FD->config('pref').'news` '
-                      .'WHERE `'.$FD->config('pref').'news_comments`.news_id=`'.$FD->config('pref').'news`.news_id '
+                      .'`'.$FD->config('pref').'comments`.content_id AS news_id, `'.$FD->config('pref').'news`.news_id, news_title '
+                      .'FROM `'.$FD->config('pref').'comments`, `'.$FD->config('pref').'news` '
+                      .'WHERE `'.$FD->config('pref').'comments`.content_id=`'.$FD->config('pref').'news`.news_id '
+                      .'       AND content_type=\'news\''
                       .'ORDER BY comment_date DESC LIMIT '.$_GET['start'].', 30', $FD->sql()->conn());
   $rows = mysql_num_rows($query);
 
@@ -251,6 +252,6 @@ echo <<<EOT
                             </tr>
                         </table>
 EOT;
- 
-                        
+
+
 ?>

--- a/www/admin/admin_statedit.php
+++ b/www/admin/admin_statedit.php
@@ -133,7 +133,7 @@ elseif (isset($_POST['do']) && $_POST['do'] == 'sync')
     $index = mysql_query("SELECT COUNT(news_id) AS 'news' FROM ".$FD->config('pref').'news', $FD->sql()->conn() );
     $sync_arr['news'] = mysql_result($index,0,'news');
 
-    $index = mysql_query("SELECT COUNT(comment_id) AS 'comments' FROM ".$FD->config('pref').'news_comments', $FD->sql()->conn() );
+    $index = mysql_query("SELECT COUNT(comment_id) AS 'comments' FROM ".$FD->config('pref').'comments', $FD->sql()->conn() );
     $sync_arr['comments'] = mysql_result($index,0,'comments');
 
     $index = mysql_query("SELECT COUNT(article_id) AS 'articles' FROM ".$FD->config('pref').'articles', $FD->sql()->conn() );

--- a/www/admin/admin_user_edit.php
+++ b/www/admin/admin_user_edit.php
@@ -261,9 +261,9 @@ elseif (
                         WHERE `cat_user` = '".$_POST['user_id']."'
         ", $FD->sql()->conn() );
 
-        // update news_comments
+        // update comments
         mysql_query ( '
-                        UPDATE '.$FD->config('pref')."news_comments
+                        UPDATE '.$FD->config('pref')."comments
                         SET `comment_poster_id` = '0',
                             `comment_poster` = '".$user_arr['user_name']."'
                         WHERE `comment_poster_id` = '".$_POST['user_id']."'

--- a/www/admin/start_content.php
+++ b/www/admin/start_content.php
@@ -16,7 +16,7 @@ $num_news_cat = mysql_result ( $index, 0, 'num_news_cat' );
 
 $index = mysql_query ( "
                         SELECT COUNT(`comment_id`) AS 'num_comments'
-                        FROM ".$FD->config('pref').'news_comments
+                        FROM ".$FD->config('pref').'comments
                         LIMIT 0,1
 ', $FD->sql()->conn() );
 $num_comments = mysql_result ( $index, 0, 'num_comments' );
@@ -43,8 +43,8 @@ if ( $num_news  > 0 ) {
     if ( $num_comments  > 0 ) {
         $index = mysql_query ( "
                                 SELECT COUNT(C.`comment_id`) AS 'best_news_com_num', N.`news_title`
-                                FROM ".$FD->config('pref').'news_comments C, '.$FD->config('pref').'news N
-                                WHERE N.`news_id` = C.`news_id`
+                                FROM ".$FD->config('pref').'comments C, '.$FD->config('pref').'news N
+                                WHERE N.`news_id` = C.`content_id` AND C.`content_type`=\'news\' 
                                 GROUP BY N.`news_title`
                                 ORDER BY `best_news_com_num` DESC
                                 LIMIT 0,1
@@ -54,7 +54,7 @@ if ( $num_news  > 0 ) {
 
         $index = mysql_query ( "
                                 SELECT COUNT(C.`comment_id`) AS 'best_com_poster_num', U.`user_name`
-                                FROM `".$FD->config('pref').'user` U, `'.$FD->config('pref').'news_comments` C
+                                FROM `".$FD->config('pref').'user` U, `'.$FD->config('pref').'comments` C
                                 WHERE C.`comment_poster_id` = U.`user_id`
                                 AND C.`comment_poster_id` > 0
                                 GROUP BY U.`user_name`

--- a/www/data/comments.php
+++ b/www/data/comments.php
@@ -81,11 +81,11 @@ if (isset($_POST['add_comment']))
 
                     $index = mysql_query( '
                                             SELECT `comment_id`
-                                            FROM `'.$FD->config('pref')."news_comments`
+                                            FROM `'.$FD->config('pref')."comments`
                                             WHERE
                                                 `comment_text` = '".$_POST['text']."'
-                                            AND
-                                                `comment_date` >  '".$duplicate_time."'
+                                            AND `content_type` = 'news'
+                                            AND `comment_date` >  '".$duplicate_time."'
                                             LIMIT 0,1
                     ", $FD->sql()->conn() );
                                              echo mysql_error();
@@ -100,8 +100,9 @@ if (isset($_POST['add_comment']))
 
                         mysql_query ( '
                                         INSERT INTO
-                                            `'.$FD->config('pref')."news_comments` (
-                                                news_id,
+                                            `'.$FD->config('pref')."comments` (
+                                                content_id,
+                                                content_type,
                                                 comment_poster,
                                                 comment_poster_id,
                                                 comment_poster_ip,
@@ -112,6 +113,7 @@ if (isset($_POST['add_comment']))
                                          VALUES
                                             (
                                                 '".$_POST['id']."',
+                                                'news',
                                                 '".$_POST['name']."',
                                                 '$userid',
                                                 '".savesql($_SERVER['REMOTE_ADDR'])."',
@@ -206,7 +208,7 @@ if ( $SHOW == TRUE ) {
     $html_active = ($html) ? 'an' : 'aus';
 
     // Kommentare erzeugen
-    $index = mysql_query('SELECT * FROM '.$FD->config('pref').'news_comments WHERE news_id = '.$_GET['id'].' ORDER BY comment_date '.$config_arr['com_sort'], $FD->sql()->conn() );
+    $index = mysql_query('SELECT * FROM '.$FD->config('pref').'comments WHERE content_id = '.$_GET['id'].' AND content_type=\'news\' ORDER BY comment_date '.$config_arr['com_sort'], $FD->sql()->conn() );
     while ($comment_arr = mysql_fetch_assoc($index))
     {
 

--- a/www/data/user.php
+++ b/www/data/user.php
@@ -66,7 +66,7 @@ if ( mysql_num_rows ( $index ) > 0 ) {
 
     $index = mysql_query ( '
         SELECT COUNT(`comment_id`) AS `number`
-        FROM `'.$FD->config('pref')."news_comments`
+        FROM `'.$FD->config('pref')."comments`
         WHERE `comment_poster_id` = '".$user_arr['user_id']."'
     ", $FD->sql()->conn() );
     $user_arr['user_num_comments'] = mysql_result ( $index, 0, 'number' );

--- a/www/data/user_list.php
+++ b/www/data/user_list.php
@@ -61,7 +61,7 @@ $query = 'SELECT `user_id`, `user_name`, `user_is_staff`, `user_is_admin`, `user
   (SELECT COUNT(`news_id`) FROM `'.$pref.'news`
    WHERE `'.$pref.'news`.`user_id` = `'.$pref.'user`.`user_id`) AS user_num_news,
 
-  (SELECT COUNT(`comment_id`) FROM `'.$pref.'news_comments`
+  (SELECT COUNT(`comment_id`) FROM `'.$pref.'comments`
    WHERE `comment_poster_id` = `'.$pref.'user`.`user_id`) AS user_num_comments,
 
   (SELECT COUNT(`article_id`) FROM `'.$pref.'articles`

--- a/www/includes/functions.php
+++ b/www/includes/functions.php
@@ -1055,7 +1055,7 @@ function display_news ($news_arr, $html_code, $fs_code, $para_handling)
     $news_arr['user_url'] = url('user', array('id' => $news_arr['user_id']));
 
     // Kommentare lesen
-    $index2 = mysql_query('SELECT comment_id FROM '.$FD->config('pref').'news_comments WHERE news_id = '.$news_arr['news_id'].'', $FD->sql()->conn() );
+    $index2 = mysql_query('SELECT comment_id FROM '.$FD->config('pref').'comments WHERE content_id = '.$news_arr['news_id'].' AND content_type=\'news\'', $FD->sql()->conn() );
     $news_arr['kommentare'] = mysql_num_rows($index2);
 
     // Get Related Links


### PR DESCRIPTION
The basic idea behind this change is to allow the implementation of comments for downloads, articles,... in the future. To achieve this, the structure of the table fs2_news_comments has been changed by adding a new varchar field ("content_type") which keeps track of whether a comment is for news, downloads or articles (or whatever might be added in future releases).

The table fs2_news_comments has been renamed to fs2_comments and the news_id field has been renamed to content_id to reflect the generalised nature of the comments stored within.

I've tested the changes and they seem to work as expected, however the tests weren't very extensive.
