### PR TITLE
fix file name in require()

### DIFF
--- a/www/libs/class_HashMapper.php
+++ b/www/libs/class_HashMapper.php
@@ -7,7 +7,7 @@
  *
  * this class provides access and datahandling for confirment hashes
  */
-require('class_hash.php');
+require('class_Hash.php');
 
 class HashMapper
 {


### PR DESCRIPTION
Corrects a file name in require(), so that the file will be found on systems with case-sensitive file names (e.g. Linux), too.
