### PR TITLE
fix error in admin_dledit.php

### DIFF
--- a/www/admin/admin_dledit.php
+++ b/www/admin/admin_dledit.php
@@ -311,7 +311,7 @@ if (isset($_POST['dlid']) || isset($_POST['optionsadd']))
                                     <input  type="button" onClick=\'document.getElementById("furl'.$j.'").value="'.$admin_dl_config_arr['quickinsert'].'";\' value="Quick-Insert Pfad"><br>
                                     <input class="text" size="30" value="'.killhtml($_POST['fsize'][$j]).'" name="fsize['.$j.']" maxlength="8" id="fsize'.$j.'"> KB<br />
                                     <input class="text" size="30" value="'.$_POST['fcount'][$j].'" name="fcount['.$j.']" maxlength="100"> Downloads<br />
-                                    Ja, Mirror: <input type="checkbox" name="fmirror['.$j.']" '.$f_checked.'"><br />
+                                    Ja, Mirror: <input type="checkbox" name="fmirror['.$j.']" '.$f_checked.'><br />
                                     L&ouml;schen: <input name="delf['.$j.']" id="delf['.$j.']" value="'.$_POST['fid'][$j].'" type="checkbox"
                                     onClick=\'delalert ("delf['.$j.']", "Soll das File (Nr. '.$i.') wirklich gelöscht werden?")\'>
                                     <input type="hidden" name="fid['.$j.']" value="'.$_POST['fid'][$j].'">


### PR DESCRIPTION
When editing a download where some files are marked as mirror,
the mirror checkbox will not be checked due to incorrect HTML
syntax for the input element (caused by a typo). As a result
all "mirror" files in the edited download will be saved as
non-mirror files with the next update - unless the mirror flag
is set again(!) by the person editing the download.

The commit fixes that bug. It also fixes some minor spelling
mistakes in the script and removes the cause of a PHP notice.
