### PR TITLE
fix disabling of magic quotes

### DIFF
--- a/www/includes/phpinit.php
+++ b/www/includes/phpinit.php
@@ -12,10 +12,10 @@ function phpinit ($session = true, $header = false, $libloader = null) {
         session_start();
 
     // Disable magic_quotes_runtime
-    if (!get_magic_quotes_gpc() || !get_magic_quotes_runtime()) {
-		ini_set('magic_quotes_gpc', 0);
-		ini_set('magic_quotes_runtime', 0);
-	}
+    if (get_magic_quotes_gpc() || get_magic_quotes_runtime()) {
+        ini_set('magic_quotes_gpc', 0);
+        ini_set('magic_quotes_runtime', 0);
+    }
 
     // Default libloader
     if (is_null($libloader)) {


### PR DESCRIPTION
Both get_magic_quotes_*() functions return true or 1, if magic quotes are enabled. Thus the not-operators in the if's condition have to be removed, if you really want to disable magic quotes.
