### PR TITLE
remove call to exec() and replace it by alternative functions

### DIFF
--- a/www/admin/admin_allphpinfo.php
+++ b/www/admin/admin_allphpinfo.php
@@ -31,7 +31,23 @@ if ( isset ( $_GET['info'] ) ) {
                                     '.$FD->text('page', 'phpinfo_phpuser').':
                                 </td>
                                 <td class="configthin" colspan="3">
-                                    '.exec('whoami').'
+                                    ';
+    //Do the required POSIX functions to get the current user's name exist?
+    // They usually do on Linux but not on Windows systems.
+    if (function_exists('posix_getuid') && function_exists('posix_getpwuid'))
+    {
+      $user_info = posix_getpwuid(posix_getuid());
+      echo htmlspecialchars($user_info['name']);
+    }
+    else
+    {
+      /* No POSIX functions available, boo! Falling back to get_current_user,
+         although that can (and often will) give incorrect result, but that's
+         the best guess so far. If that bugs you, run your server on a POSIX-
+         compatible system or enable PHP's POSIX extension. */
+      echo htmlspecialchars(get_current_user());
+    }
+    echo '
                                 </td>
                             </tr>
                             <tr><td class="space"></td></tr>


### PR DESCRIPTION
The exec() function is usually disabled in most hosted environments, because of security concerns. Furthermore the call to 'whoami' won't work on Windows servers running PHP, so we should be more portable in determining the current user's name.

Yes, people should usually avoid Windows as a server system OS, but nevertheless there are PHP binaries for Windows, too, so we should try to support that as well.

The replacement function for Windows, get_current_user(), might return wrong results, because the user who owns the script might be different from the user who runs PHP, but the POSIX functions used for systems with POSIX support should properly return the actual user's name. So everything's fine on Linux and POSIX-compatible systems. :)
