### PR TITLE
update b8 to version 0.6.1

### DIFF
--- a/www/resources/spamdetector/b8/storage/storage_base.php
+++ b/www/resources/spamdetector/b8/storage/storage_base.php
@@ -138,7 +138,7 @@ abstract class b8_storage_base
 			
 		}
 		
-		# Here, we have all availible data in $token_data.
+		# Here, we have all available data in $token_data.
 		
 		$return_data_tokens = array();
 		$return_data_degenerates = array();
@@ -193,7 +193,7 @@ abstract class b8_storage_base
 		# First get the internals, including the ham texts and spam texts counter
 		$internals = $this->get_internals();
 		
-		# Then, fetch all data for all tokens we have (and update their lastseen parameters)
+		# Then, fetch all data for all tokens we have
 		$token_data = $this->_get_query(array_keys($tokens));
 		
 		# Process all tokens to learn/unlearn


### PR DESCRIPTION
This commit updates the b8 files (used in comment spam detector) to [version 0.6.1](http://nasauber.de/blog/T/142/b8_0.6.1).
Neither interfaces nor database formats have changed, so this should not cause any troubles.

Class b8_storage_mysql does not get updated during this commit, because our implementation already uses PDO_MySQL instead of the old mysql API used by the offical b8 codebase's class and the fix for the potential SQL injection is already included in our PDO version.
