### PR TITLE
add missing global declaration in player_flv_include.php

### DIFF
--- a/www/resources/player/player_flv_include.php
+++ b/www/resources/player/player_flv_include.php
@@ -147,8 +147,6 @@ function get_player ( $MULTI, $WIDTH = true, $HEIGHT = true, $MODIFIER = false )
 }
 
 function get_video_url($url, $type, $dl_id = 0) {
-    global $FD;
-
     // Existing Download?
     if ($type <= 1 && $dl_id != 0) {
         $type = 1;
@@ -173,6 +171,8 @@ function get_video_url($url, $type, $dl_id = 0) {
     return $url;
 }
 function get_video_text($url, $title, $type, $dl_id = 0) {
+    global $FD;
+
     // get url
     $url = get_video_url($url, $title, $type, $dl_id);
     if (empty($url)) {
@@ -187,6 +187,8 @@ function get_video_text($url, $title, $type, $dl_id = 0) {
     }
 }
 function get_video_bbcode($url, $title, $type, $dl_id = 0) {
+    global $FD;
+
     // get url
     $url = get_video_url($url, $title, $type, $dl_id);
     if (empty($url)) {


### PR DESCRIPTION
Fixes fatal PHP error when calling get_video_text() or get_video_bbcode().

("PHP Fatal error:  Call to a member function text() on a non-object in .../www/resources/player/player_flv_include.php on line 184")
