### PR TITLE
Alix6 cimgfix

### DIFF
--- a/www/admin/admin_cimg.php
+++ b/www/admin/admin_cimg.php
@@ -46,7 +46,7 @@ if (isset($_FILES['cimg']) AND (isset($_POST['newname']) OR $_POST['oldname'] ==
 
   if (!image_exists('media/content/',$_POST['newname'])  AND !image_exists('media/content/',$_POST['newname'].'_s'))
   {
-    $upload = upload_img($_FILES['cimg'], 'media/content/', $_POST['newname'], 1024*1024, 9999, 9999);
+    $upload = upload_img($_FILES['cimg'], 'media/content/', $_POST['newname'], 1024*1024*5, 9999, 9999);
     $message = upload_img_notice ( $upload );
     if ($make_thumb) {
       $thumb = create_thumb_from ( image_url ( 'media/content/', $_POST['newname'], FALSE, TRUE ) , $_POST['width'], $_POST['height'] );


### PR DESCRIPTION
Angegeben war 5MB als Maximale Uploadgröße für Inhaltsbilder. Akzeptiert hat er allerdings nur 1 MB dieser wert wurde hiermit wieder auf 5MB hochgesetzt.
