### PR TITLE
add missing closing form tag to new password template

### DIFF
--- a/www/styles/default/0_user.tpl
+++ b/www/styles/default/0_user.tpl
@@ -157,7 +157,7 @@
       </td>
     </tr>
   </table>
-
+</form>
 <p>Falls du keinen Zugriff mehr auf diese E-Mail-Adresse haben solltest, musst du dir leider einen <a href="$URL(register)">neuen Account</a> anlegen.</p>
 <!--section-end::NEW_PASSWORD-->
 

--- a/www/styles/lightfrog/0_user.tpl
+++ b/www/styles/lightfrog/0_user.tpl
@@ -157,7 +157,7 @@
       </td>
     </tr>
   </table>
-
+</form>
 <p>Falls du keinen Zugriff mehr auf diese E-Mail-Adresse haben solltest, musst du dir leider einen <a href="$URL(register)">neuen Account</a> anlegen.</p>
 <!--section-end::NEW_PASSWORD-->
 


### PR DESCRIPTION
add missing closing form tag to new password template in lightfrog and default style template
