### PR TITLE
fix image links in popup viewer

### DIFF
--- a/www/imageviewer.php
+++ b/www/imageviewer.php
@@ -95,7 +95,7 @@ set_style();
 
                 $data_array['next_url'] = 'imageviewer.php?id='.$next_id;
                 $data_array['next_link'] = '<a href="'.$data_array['next_url'].'" target="_self">'.$FD->text('frontend', 'popupviewer_next_text').'</a>';
-                $data_array['next_image_link'] = '<a href="'.$data_array['next_url'].'" target="_self">'.$FD->text('frontend', 'popupviewer_next_image').'</a>';
+                $data_array['next_image_link'] = '<a href="'.$data_array['next_url'].'" target="_self"><img src="styles/'.$FD->config('style').'/icons/next.gif" alt="'.$FD->text('frontend', 'popupviewer_next_text').'" title="'.$FD->text('frontend', 'popupviewer_next_text').'"></a>';
             }
 
             // exists a PREVIOUS image?
@@ -112,7 +112,7 @@ set_style();
 
                 $data_array['prev_url'] = 'imageviewer.php?id='.$prev_id;
                 $data_array['prev_link'] = '<a href="'.$data_array['prev_url'].'" target="_self">'.$FD->text('frontend', 'popupviewer_prev_text').'</a>';
-                $data_array['prev_image_link'] = '<a href="'.$data_array['prev_url'].'" target="_self">'.$FD->text('frontend', 'popupviewer_prev_image').'</a>';
+                $data_array['prev_image_link'] = '<a href="'.$data_array['prev_url'].'" target="_self"><img src="styles/'.$FD->config('style').'/icons/previous.gif" alt="'.$FD->text('frontend', 'popupviewer_prev_text').'" title="'.$FD->text('frontend', 'popupviewer_prev_text').'"></a>';
             }
 
         }

--- a/www/lang/de_DE/frontend.txt
+++ b/www/lang/de_DE/frontend.txt
@@ -88,10 +88,8 @@ news_title:                      News
 comment_added:                   Kommentar wurde hinzugefügt
 comment_not_added:               Kommentar wurde nicht hinzugefügt
 comment_duplicate:               Dieser Kommentar ist das Duplikat eines Kommentars der gerade erst hinzugefügt wurde
-popupviewer_next_text:           Nächstes Bild
-popupviewer_next_image:          <img src="styles//icons/next.gif" alt="N&auml;chstes Bild" title="N&auml;chstes Bild">
+popupviewer_next_text:           N&auml;chstes Bild
 popupviewer_prev_text:           Vorheriges Bild
-popupviewer_prev_image:          <img src="styles//icons/previous.gif" alt="Vorheriges Bild" title="Vorheriges Bild">
 download_file:                   Datei
 download_files:                  Dateien
 download_search_for:             Suche nach

--- a/www/lang/en_US/frontend.txt
+++ b/www/lang/en_US/frontend.txt
@@ -89,9 +89,7 @@ comment_added:                   Comment has been added
 comment_not_added:               Comment has not been added
 comment_duplicate:               This comment is a duplicate of a comment that has been added recently
 popupviewer_next_text:           Next Image
-popupviewer_next_image:          <img src="styles//icons/next.gif" alt="Next Image" title="Next Image">
 popupviewer_prev_text:           Previous Image
-popupviewer_prev_image:          <img src="styles//icons/previous.gif" alt="Previous Image" title="Previous Image">
 download_file:                   File
 download_files:                  Files
 download_search_for:             Search for


### PR DESCRIPTION
Image links for previous and next image in image viewer do not work as in alix5 any more, i.e. no image for navigating to previous/next image is shown because the image URL is wrong. This pull request fixes that issue by generating the correct URL again.
