### PR TITLE
cimg bugfix

### DIFF
--- a/www/admin/admin_cimg.php
+++ b/www/admin/admin_cimg.php
@@ -39,6 +39,8 @@ if (isset($_FILES['cimg']) AND (isset($_POST['newname']) OR $_POST['oldname'] ==
   if ($_POST['oldname'] == 1) {
       $_POST['newname'] = basename ($_FILES['cimg']['name'],'.'.$oldname_data);
   }
+  
+  $oldname_data = strtolower($oldname_data);
 
   settype ($_POST['cat'], 'integer');
   settype ($_POST['width'], 'integer');


### PR DESCRIPTION
Wenn ein Inhaltsbild hinzugefügt wird, und dessen Dateityp groß
geschrieben wurde (bsp. test.JPG) wird das Bild mit klein geschriebenen
Dateitypen in den media/content Ordner geladen.
In die Datenbank wird allerdings ein großes JPG eingefügt.

Deshalb wird hier nun durch strtolower der String für den Datentypen
verkleinert, allerdings erst, nachdem dieser aus dem basis-string
entfernt wurde.
