### PR TITLE
fix used name of text for multiple choice polls

### DIFF
--- a/www/applets/poll-system.php
+++ b/www/applets/poll-system.php
@@ -178,7 +178,7 @@ if (
 
 elseif (isset($poll_arr['poll_id']) && !checkVotedPoll($poll_arr['poll_id'])) {
 
-    $poll_arr['poll_type_text'] = ( $poll_arr['poll_type'] == 1 ) ? $FD->text("frontend", "multiple_choise") : $FD->text("frontend", "single_choice");
+    $poll_arr['poll_type_text'] = ( $poll_arr['poll_type'] == 1 ) ? $FD->text("frontend", "multiple_choice") : $FD->text("frontend", "single_choice");
 
     $index2 = $FD->db()->conn()->query('SELECT * FROM '.$FD->env('DB_PREFIX').'poll_answers WHERE poll_id = '.$poll_arr['poll_id'].' ORDER BY answer_id ASC');
     initstr($antworten);

--- a/www/data/polls.php
+++ b/www/data/polls.php
@@ -35,7 +35,7 @@ if ( isset($_GET['id']) ) {
     {
         $poll_arr['poll_start'] = date_loc ( $FD->config('date') , $poll_arr['poll_start']);
         $poll_arr['poll_end'] = date_loc ( $FD->config('date') , $poll_arr['poll_end']);
-        $poll_arr['poll_type'] = ( $poll_arr['poll_type'] == 1 ) ? $FD->text("frontend", "multiple_choise") : $FD->text("frontend", "single_choice");
+        $poll_arr['poll_type'] = ( $poll_arr['poll_type'] == 1 ) ? $FD->text("frontend", "multiple_choice") : $FD->text("frontend", "single_choice");
         // all votes
         $index = $FD->db()->conn()->query ( "
                         SELECT SUM(`answer_count`) AS 'all_votes'
@@ -137,7 +137,7 @@ else {
         $poll_arr['poll_url'] = url('polls', array('id' => $poll_arr['poll_id']));
         $poll_arr['poll_start'] = date_loc ( $FD->config('date') , $poll_arr['poll_start'] );
         $poll_arr['poll_end'] = date_loc ( $FD->config('date') , $poll_arr['poll_end'] );
-        $poll_arr['poll_type'] = ( $poll_arr['poll_type'] == 1 ) ? $FD->text("frontend", "multiple_choise") : $FD->text("frontend", "single_choice");
+        $poll_arr['poll_type'] = ( $poll_arr['poll_type'] == 1 ) ? $FD->text("frontend", "multiple_choice") : $FD->text("frontend", "single_choice");
 
         // all votes
         $index2 = $FD->db()->conn()->query ( "


### PR DESCRIPTION
Some scripts use "multiple_choi**s**e" instead of the correct "multiple_choi**c**e" key for frontend texts, resulting in an unlocalised string showing up for multiple choice polls.
