### PR TITLE
Missing language & preg_relpace with eval-modifier

### DIFF
--- a/www/admin/admin_news_edit.php
+++ b/www/admin/admin_news_edit.php
@@ -59,7 +59,7 @@ function action_delete_get_data ( $IDS )
         $index = $FD->db()->conn()->query ( 'SELECT * FROM '.$FD->env('DB_PREFIX')."news WHERE news_id = '".$NEWS_ID."'" );
         $news_arr = $index->fetch(PDO::FETCH_ASSOC);
 
-        $news_arr['news_date_formated'] = ''.$FD->text('admin', 'on').' <b>' . date ( $FD->text('admin', 'date_format') , $news_arr['news_date'] ) . '</b> '.$FD->text('admin', 'at').' <b>' . date ( $FD->text('admin', 'time_format') , $news_arr['news_date'] ) . '</b>';
+        $news_arr['news_date_formated'] = ''.$FD->text('admin', 'at_date').' <b>' . date ( $FD->text('admin', 'date') , $news_arr['news_date'] ) . '</b> '.$FD->text('admin', 'at_time').' <b>' . date ( $FD->text('admin', 'time') , $news_arr['news_date'] ) . '</b>';
 
         $index2 = $FD->db()->conn()->query("SELECT COUNT(comment_id) AS 'number' FROM ".$FD->env('DB_PREFIX').'comments WHERE content_id = '.$news_arr['news_id'].' AND content_type=\'news\'' );
         $news_arr['num_comments'] = $index2->fetchColumn();
@@ -113,10 +113,10 @@ function action_delete_display_page ( $return_arr )
                             </span>
                             <br>
                             <span class="small">
-                                '.$FD->text('admin', 'by_posted').' <b>'.$news_arr['user_name'].'</b>
+                                '.$FD->text('admin', 'by').' <b>'.$news_arr['user_name'].'</b>
                                 '.$news_arr['news_date_formated'].'</b>
                                 '.$FD->text('admin', 'in').' <b>'.$news_arr['cat_name'].'</b>,
-                                <b>'.$news_arr['num_comments'].'</b> '.$FD->text('admin', 'comments').'
+                                <b>'.$news_arr['num_comments'].'</b> '.$FD->text('page', 'comments').'
                             </span>
                         </td>
                         <td style="width:15px;"></td>

--- a/www/lang/de_DE/admin/admin_articles_edit.txt
+++ b/www/lang/de_DE/admin/admin_articles_edit.txt
@@ -10,3 +10,7 @@ edit_filter_arttitle: Titel
 edit_filter_url: URL
 edit_select_article: Artikel auswählen
 edit_entries_found: Datensätze gefunden
+
+delete_title:          Artikel löschen
+delete_question:       Artikel wirklich löschen?
+delete_view_article:   Artikel ansehen

--- a/www/lang/de_DE/admin/admin_news_edit.txt
+++ b/www/lang/de_DE/admin/admin_news_edit.txt
@@ -34,3 +34,6 @@ selection_comments:         Kommentare bearbeiten
 #Löschen
 news_deleted:               News wurden gelöscht
 news_not_deleted:           News wurden nicht gelöscht
+news_delete_title:          News löschen
+news_delete_question:       News wirklich löschen?
+news_delete_view_news:      News ansehen

--- a/www/lang/en_US/admin/admin_articles_edit.txt
+++ b/www/lang/en_US/admin/admin_articles_edit.txt
@@ -10,3 +10,7 @@ edit_filter_arttitle: Title
 edit_filter_url: URL
 edit_select_article: Select article
 edit_entries_found: records found
+
+delete_title:          Delete article
+delete_question:       Delete article?
+delete_view_article:   View article

--- a/www/lang/en_US/admin/admin_news_edit.txt
+++ b/www/lang/en_US/admin/admin_news_edit.txt
@@ -1,7 +1,7 @@
 # Import default texts
 #@admin/admin_news
 
-# Kommentare
+# comments
 comments_select_title:              Edit comments
 comments_content:                   Content
 comments_info:                      Information
@@ -11,7 +11,7 @@ comment_deleted:                    Comment has been deleted successfully
 # News
 news_not_found:                     No News found!
 
-#filter
+# filter
 filter_title:               Filter & sort order
 cat_filter:                 Filter
 all_cats:                   All categories
@@ -20,17 +20,20 @@ filter_date:                Date
 filter_id:                  ID
 filter_newstitle:           Title
 
-#search
+# search
 search_fulltext: Full text
 search_id: IDs
 search_url: URLs
 
-# Auswahlliste
+# list
 select_news:                Select news
 comments:                   Comments
 links:                      Links
 selection_comments:         Edit comments
 
-#Löschen
+# delete
 news_deleted:               News has been deleted
 news_not_deleted:           News has not been deleted
+news_delete_title:          Delete news
+news_delete_question:       Delete news?
+news_delete_view_news:      View news

--- a/www/libs/class_adminpage.php
+++ b/www/libs/class_adminpage.php
@@ -5,7 +5,7 @@
  * @file     class_adminpage.php
  * @folder   /libs
  * @version  0.6
- * @author   Satans Kr�melmonster, Sweil
+ * @author   Satans Krümelmonster, Sweil
  *
  * provides functions to manage admin-cp display-issues
  */
@@ -120,7 +120,9 @@ class adminpage {
                 }, $tmpval);
 
                 // replace common
-                $tmpval = preg_replace_callback("/<!--COMMON::(.*?)-->/", function($matches){ return $this->commonValue($matches[1]);}, $tmpval);
+                $tmpval = preg_replace_callback("/<!--COMMON::(.*?)-->/", function($matches){
+                    return $this->commonValue($matches[1]);
+                }, $tmpval);
             }
 
             // clear rest

--- a/www/libs/class_adminpage.php
+++ b/www/libs/class_adminpage.php
@@ -5,7 +5,7 @@
  * @file     class_adminpage.php
  * @folder   /libs
  * @version  0.6
- * @author   Satans Krümelmonster, Sweil
+ * @author   Satans Krï¿½melmonster, Sweil
  *
  * provides functions to manage admin-cp display-issues
  */
@@ -16,12 +16,19 @@ class adminpage {
     private $tpl    = array();
     private $cond   = array();
     private $text   = array();
+
+    /**
+     * @var lang
+     */
     private $lang   = null;
+
+    /**
+     * @var lang
+     */
     private $common = null;
 
 
     function __construct ($pagefile) {
-        global $FD;
         $this->name = substr($pagefile, 0, -4);
 
         // load tpl file
@@ -108,10 +115,12 @@ class adminpage {
             // replace data from langfiles
             if ($lang) {
                 // replace language
-                $tmpval = preg_replace("/<!--LANG::(.*?)-->/e", '$this->langValue(\'$1\')', $tmpval);
+                $tmpval = preg_replace_callback("/<!--LANG::(.*?)-->/", function($matches){
+                    return $this->langValue($matches[1]);
+                }, $tmpval);
 
                 // replace common
-                $tmpval = preg_replace("/<!--COMMON::(.*?)-->/e", '$this->commonValue(\'$1\')', $tmpval);
+                $tmpval = preg_replace_callback("/<!--COMMON::(.*?)-->/", function($matches){ return $this->commonValue($matches[1]);}, $tmpval);
             }
 
             // clear rest
@@ -137,22 +146,23 @@ class adminpage {
         $num = 0;
         $push = array();
         
-        $tokenizer = create_function("\$match,&\$num,&\$name,&\$push", "
-            if (\$match[1] == \"IF\") {
-                \$name[\$num] = \$match[2];
-                array_push(\$push, \$num);
-                return \"<!--IF::\".\$num++.\"-->\";
+        $tokenizer = function($match) use (&$num, &$name, &$push)
+        {
+            if ($match[1] == "IF") {
+                $name[$num] = $match[2];
+                array_push($push, $num);
+                return "<!--IF::".$num++."-->";
 
-            } elseif (\$match[1] == \"ELSE\") {
-                return \"<!--ELSE::\".end(\$push).\"-->\";
+            } elseif ($match[1] == "ELSE") {
+                return "<!--ELSE::".end($push)."-->";
 
-            } elseif (\$match[1] == \"ENDIF\") {
-                return \"<!--ENDIF::\".array_pop(\$push).\"-->\";
+            } elseif ($match[1] == "ENDIF") {
+                return "<!--ENDIF::".array_pop($push)."-->";
             }
-            return \$match[0];       
-        ");
+            return $match[0];
+        };
 
-        $tpl = preg_replace('/(?|<!\-\-(IF)::(.+?)\-\->|<!\-\-(ELSE)\-\->|<!\-\-(ENDIF)\-\->)/e', '$tokenizer(array(\'$0\',\'$1\',\'$2\'),$num,$name,$push)', $tpl);
+        $tpl = preg_replace_callback('/(?|<!\-\-(IF)::(.+?)\-\->|<!\-\-(ELSE)\-\->|<!\-\-(ENDIF)\-\->)/', $tokenizer, $tpl);
 
         return $tpl;
     }
@@ -168,6 +178,7 @@ class adminpage {
 
         // get from default lang
         } else {
+            /** @var GlobalData $FD */
             global $FD;
             return $FD->text('page', $name);
         }
@@ -180,6 +191,7 @@ class adminpage {
 
         // get from default lang
         } else {
+            /** @var GlobalData $FD */
             global $FD;
             return $FD->text('admin', $name);
         }
@@ -204,4 +216,3 @@ class adminpage {
         return $this->lang;
     }
 }
-?>


### PR DESCRIPTION
The eval-modifier is deprecated since PHP 5.5 and was removed in PHP 7 (See [the manual](https://secure.php.net/manual/en/reference.pcre.pattern.modifiers.php#reference.pcre.pattern.modifiers.eval)). We should get rid of it, too.

Some language-tokens are missing so the deleting-dialog for news and articles looks a bit weird.
